### PR TITLE
Improve configuration consistency and simplify deployment template

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -201,8 +201,6 @@ spec:
             - name: keystores
               mountPath: /home/wso2carbon/{{ .Values.deployment.productPackName }}-{{ .Values.deployment.buildVersion }}/repository/resources/security/{{ .Values.deploymentToml.keystore.primary.fileName }}
               subPath: {{ .Values.deploymentToml.keystore.primary.fileName }}
-            {{- end }}
-            {{- if .Values.deployment.externalJKS.enabled }}
             - name: keystores
               mountPath: /home/wso2carbon/{{ .Values.deployment.productPackName }}-{{ .Values.deployment.buildVersion }}/repository/resources/security/{{ .Values.deploymentToml.truststore.fileName }}
               subPath: {{ .Values.deploymentToml.truststore.fileName }}

--- a/templates/envoyProxy.yaml
+++ b/templates/envoyProxy.yaml
@@ -28,5 +28,5 @@ spec:
         layers:
           - name: runtime_0
             static_layer:
-              envoy.reloadable_features.max_response_headers_size_kb: {{ .Values.deployment.gateway.max_response_headers_size_kb }}
+              envoy.reloadable_features.max_response_headers_size_kb: {{ .Values.deployment.gateway.maxResponseHeadersSizeKb }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -68,7 +68,7 @@ deployment:
     backendCACertificate:
       configMapName: "wso2-ca-bundle"
       hostname: "localhost"
-    max_response_headers_size_kb: "64"
+    maxResponseHeadersSizeKb: 64
     createGatewayClass: true
   rbac:
     aws:

--- a/values.yaml
+++ b/values.yaml
@@ -68,7 +68,7 @@ deployment:
     backendCACertificate:
       configMapName: "wso2-ca-bundle"
       hostname: "localhost"
-    maxResponseHeadersSizeKb: 64
+    maxResponseHeadersSizeKb: "64"
     createGatewayClass: true
   rbac:
     aws:


### PR DESCRIPTION
This pull request makes minor improvements to configuration consistency and cleans up the deployment template. The most notable changes are:

Configuration consistency:

* Renamed the `max_response_headers_size_kb` field to `maxResponseHeadersSizeKb` and changed its value from a string to an integer in `values.yaml` for improved naming consistency and type correctness.

Template cleanup:

* Removed an unnecessary conditional (`if .Values.deployment.externalJKS.enabled`) in the `deployment.yaml` template, simplifying the keystore volume mount logic.