### PR TITLE
Refactor gateway configuration and update README for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -858,7 +858,7 @@ helm install "$RELEASE_NAME" wso2/identity-server --version 7.2.0-1  -n "$NAMESP
 | openShiftKindAPIVersions.route | string | `"route.openshift.io/v1"` | OpenShift API version for kind Route |
 | wso2.subscription.password | string | `""` | WSO2 account password |
 | wso2.subscription.username | string | `""` | WSO2 account username |
-| gateway.createGatewayClass | bool | `true` | Create a GatewayClass resource. Set to `false` if Envoy Gateway already manages its own cluster-scoped GatewayClass. |
+| deployment.gateway.createGatewayClass | bool | `true` | Create a GatewayClass resource. Set to `false` if Envoy Gateway already manages its own cluster-scoped GatewayClass. |
 | gatewayKindAPIVersions.gateway | string | `"gateway.networking.k8s.io/v1"` | API version for Gateway. |
 | gatewayKindAPIVersions.gatewayClass | string | `"gateway.networking.k8s.io/v1"` | API version for GatewayClass. |
 | gatewayKindAPIVersions.httpRoute | string | `"gateway.networking.k8s.io/v1"` | API version for HTTPRoute. |

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ ___
 
 ### Infrastructure
 - Running Kubernetes cluster ([minikube](https://kubernetes.io/docs/tasks/tools/#minikube) or an alternative cluster)
-- Kubernetes ingress controller ([NGINX Ingress](https://github.com/kubernetes/ingress-nginx) recommended)
 - Ingress/Gateway Support (Choose one):
     - Kubernetes ingress controller ([NGINX Ingress](https://github.com/kubernetes/ingress-nginx) recommended).
     - Envoy Gateway (Required for the Kubernetes Gateway API pattern).
@@ -95,7 +94,7 @@ There are two ways to install the WSO2 Identity Server using the Helm chart.
     helm repo add wso2 https://helm.wso2.com && helm repo update
     ```
 
-2. Install the Helm chart from the Helm repository(Choose one).
+2. Install the Helm chart from the Helm repository (Choose one).
 
     a. Standard installation with NGINX Ingress:
         
@@ -134,7 +133,7 @@ If you prefer to build the chart from the source, follow the steps below:
 
     **Note:** You can customize the product configuration by modifying the `kubernetes-is/confs/deployment.toml` file after cloning the repository.
 
-2. Install the Helm chart from the cloned repository(Choose one):
+2. Install the Helm chart from the cloned repository (Choose one):
 
     a. Standard installation with NGINX Ingress:
     
@@ -859,3 +858,9 @@ helm install "$RELEASE_NAME" wso2/identity-server --version 7.2.0-1  -n "$NAMESP
 | openShiftKindAPIVersions.route | string | `"route.openshift.io/v1"` | OpenShift API version for kind Route |
 | wso2.subscription.password | string | `""` | WSO2 account password |
 | wso2.subscription.username | string | `""` | WSO2 account username |
+| gateway.createGatewayClass | bool | `true` | Create a GatewayClass resource. Set to `false` if Envoy Gateway already manages its own cluster-scoped GatewayClass. |
+| gatewayKindAPIVersions.gateway | string | `"gateway.networking.k8s.io/v1"` | API version for Gateway. |
+| gatewayKindAPIVersions.gatewayClass | string | `"gateway.networking.k8s.io/v1"` | API version for GatewayClass. |
+| gatewayKindAPIVersions.httpRoute | string | `"gateway.networking.k8s.io/v1"` | API version for HTTPRoute. |
+| gatewayKindAPIVersions.Backend | string | `"gateway.envoyproxy.io/v1alpha1"` | API version for Envoy Gateway Backend. |
+| gatewayKindAPIVersions.EnvoyProxy | string | `"gateway.envoyproxy.io/v1alpha1"` | API version for EnvoyProxy. |

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -201,8 +201,6 @@ spec:
             - name: keystores
               mountPath: /home/wso2carbon/{{ .Values.deployment.productPackName }}-{{ .Values.deployment.buildVersion }}/repository/resources/security/{{ .Values.deploymentToml.keystore.primary.fileName }}
               subPath: {{ .Values.deploymentToml.keystore.primary.fileName }}
-            {{- end }}
-            {{- if .Values.deployment.externalJKS.enabled }}
             - name: keystores
               mountPath: /home/wso2carbon/{{ .Values.deployment.productPackName }}-{{ .Values.deployment.buildVersion }}/repository/resources/security/{{ .Values.deploymentToml.truststore.fileName }}
               subPath: {{ .Values.deploymentToml.truststore.fileName }}

--- a/templates/envoyProxy.yaml
+++ b/templates/envoyProxy.yaml
@@ -28,5 +28,5 @@ spec:
         layers:
           - name: runtime_0
             static_layer:
-              envoy.reloadable_features.max_response_headers_size_kb: {{ .Values.deployment.gateway.max_response_headers_size_kb }}
+              envoy.reloadable_features.max_response_headers_size_kb: {{ .Values.deployment.gateway.maxResponseHeadersSizeKB }}
 {{- end }}

--- a/templates/gatewayClass.yaml
+++ b/templates/gatewayClass.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.deployment.gateway.enabled }}
+{{- if and .Values.deployment.gateway.enabled .Values.deployment.gateway.createGatewayClass }}
 # Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
 #
 # WSO2 LLC. licenses this file to you under the Apache License,

--- a/values.yaml
+++ b/values.yaml
@@ -68,7 +68,8 @@ deployment:
     backendCACertificate:
       configMapName: "wso2-ca-bundle"
       hostname: "localhost"
-    max_response_headers_size_kb: "64"
+    maxResponseHeadersSizeKB: "64"
+    createGatewayClass: true
   rbac:
     aws:
       annotations:


### PR DESCRIPTION
## Summary

This PR standardizes naming conventions in the Helm configuration, improves GatewayClass provisioning flexibility, cleans up README documentation, and consolidates keystore mounting logic internally.

### Changes Included

### Gateway Configuration Overhaul

- Renamed `max_response_headers_size_kb` to `maxResponseHeadersSizeKB` in `values.yaml` and `envoyProxy.yaml` to align with the camelCase naming convention.
- Added a configurable `createGatewayClass` flag (default: `true`).
  - When set to `false`, the Helm chart skips creating the `GatewayClass` resource.
  - This is useful in environments where Envoy Gateway manages cluster-scoped `GatewayClass` resources externally.

### Documentation Updates

- Removed duplicate ingress controller prerequisites from the `README.md`.
- Corrected minor spacing and formatting issues in the installation instructions.
- Added the following new configuration options to the `values.yaml` reference table in the README:
  - `createGatewayClass`
  - `gatewayKindAPIVersions`

### Helm Template Cleanup

- Consolidated `externalJKS.enabled` conditional blocks in `deployment.yaml`.
- Simplified keystore and truststore mount handling to reduce duplication and improve maintainability.